### PR TITLE
Fix for point calculation and improvement

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -263,6 +263,7 @@ kyoku.init = function(leaf)
     this.dealerseat  = leaf.ju;
     this.ldseat      = -1; //who dealt the last tile
     this.nriichi     = 0; //number of current riichis - needed for scores, abort workaround
+    this.priichi     = false; // has pending riichi
     this.nkan        = 0; //number of current kans - only for abort workaround
     //pao rule
     this.nowinds     = new Array(4).fill(0);//counter for each players open wind pons/kans
@@ -342,7 +343,7 @@ function generatelog(mjslog)
 
                 if (e.is_liqi) //riichi delcaration
                 {
-                    kyoku.nriichi++;
+                    kyoku.priichi = true;
                     symbol = "r" + symbol;
                 }
                 kyoku.discards[e.seat].push(symbol);
@@ -356,6 +357,11 @@ function generatelog(mjslog)
             }
             case "RecordDealTile":
             {   //draw - after kan this gets passed the new dora
+                if (kyoku.priichi) {
+                    kyoku.priichi = false;
+                    kyoku.nriichi++;
+                }
+
                 if (e.doras && e.doras.length > kyoku.doras.length)
                     kyoku.doras = e.doras.map(f => tm2t(f));
 
@@ -365,6 +371,11 @@ function generatelog(mjslog)
             }
             case "RecordChiPengGang":
             {   //call - chi, pon, daiminkan
+                if (kyoku.priichi) {
+                    kyoku.priichi = false;
+                    kyoku.nriichi++;
+                }
+
                 switch (e.type)
                 {
                     case 0:
@@ -502,6 +513,11 @@ function generatelog(mjslog)
             //////////////////////////////////////////////////////
             case "RecordLiuJu" :
             {   //abortion
+                if (kyoku.priichi) {
+                    kyoku.priichi = false;
+                    kyoku.nriichi++;
+                }
+
                 var entry = kyoku.dump([]);
 
                 if (1 == e.type)

--- a/convert.js
+++ b/convert.js
@@ -120,6 +120,10 @@ function parsehule(h, kyoku)
     var liableseat  = -1;
     var liablefor   = 0;
 
+    h.fans = h.fans.sort(function (l, r) {
+        return cfg.fan.fan.map_[l.id].show_index - cfg.fan.fan.map_[r.id].show_index;
+    });
+
     if (h.yiman)
     {   //only worth checking yakuman hands
         h.fans.forEach(e =>


### PR DESCRIPTION
Hi developer,

I have been using this script for exporting logs for a while and discovered some bugs in this script.
1. Bug: the point calculation is wrong when the game aborts or a player deals into another's hand upon riichi.
2. Han's are not sorted in log replays as in official games.

I am not sure whether my fixes are correct. The bugs seem to be fixed with my limited tests.

Thank you!
