### PR TITLE
fix: update seat for nukidora ron

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -499,6 +499,7 @@ function generatelog(mjslog)
                 //    kyoku.discards[e.seat].push("f" + TSUMOGIRI);
                 //else
                 kyoku.discards[e.seat].push("f44");
+                kyoku.ldseat = e.seat; // for nukidora ron
 
                 return;
             }


### PR DESCRIPTION
This PR fixes a bug that happens in the point delta calculation in 3-player game Nukidora double ron.

Nukidora can act like chankan in 3-player game, we need to update the `ldseat` for ron calculation.

eg. <https://game.maj-soul.com/1/?paipu=221014-71191e6f-b1c5-44f7-9c2a-e0595fdc2255_a18254696>

before: `[ 12000, -12000, 0 ]` `[ 0, -16000, 0 ]` (wrong because seat not updated)

after: `[ 12000, 0, -12000 ]`  `[ 0, 16000, -16000 ]` (correct)