### PR TITLE
Fix tonpuu and hanchan disp for 3p

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -618,11 +618,11 @@ function parse(record)
         nakas    = record.head.config.mode.detail_rule.dora_count;
         TSUMOLOSSOFF = (3 == nplayers) ? ! record.head.config.mode.detail_rule.have_zimosun : false;
     }
-    if (1 == record.head.config.mode.mode)
+    if (1 == record.head.config.mode.mode || 11 == record.head.config.mode.mode)
     {
         ruledisp += RUNES.tonpuu[NAMEPREF]; //" East";
     }
-    else if (2 == record.head.config.mode.mode)
+    else if (2 == record.head.config.mode.mode || 12 == record.head.config.mode.mode)
     {
         ruledisp += RUNES.hanchan[NAMEPREF]; //" South";
     }


### PR DESCRIPTION
The GameMode for 3p is `11`(tonpuu) and `12`(hanchan), while the current parser only considers gamemodes in 4p(which is `1` for tonpuu and `2` for hanchan), and skips parsing for 3p games.

This PR fixes the issue for rule disp for 3p, eg. `三王座の間南喰赤` for 
```
GameConfig {
  category: 2,
  mode: GameMode { mode: 12, detail_rule: GameDetailRule {} },
  meta: GameMetaData { mode_id: 26 }
}
```

